### PR TITLE
config connection bug fixed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,10 @@ services:
             context: ./keupang-user
         ports:
             - "8081:8081"
+        deploy:
+            mode: replicated
+            restart_policy:
+                condition: on-failure
         depends_on:
             - eureka-server
             - config-server

--- a/keupang-config-server/build.gradle
+++ b/keupang-config-server/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
     //junit
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //httpclient
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
+
 }
 
 dependencyManagement {

--- a/keupang-config-server/src/main/resources/application.yml
+++ b/keupang-config-server/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
                     private-key: ${private_key}
 server:
     port: 9000
+logging:
+    level:
+        org.springframework.cloud.config.server: DEBUG
 
 
 

--- a/keupang-user/src/main/resources/application.yml
+++ b/keupang-user/src/main/resources/application.yml
@@ -3,9 +3,9 @@ spring:
         name: user
     profiles:
         active: dev
-    config:
-        import: optional:configserver:http://${security_username}:${security_password}@config-server:9000
 
+    config:
+        import: configserver:http://${security_username}:${security_password}@config-server:9000
     datasource:
         url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${USER_DB_NAME}
         username: ${DB_USERNAME}
@@ -17,6 +17,7 @@ spring:
         show-sql: true
         database-platform: org.hibernate.dialect.MySQLDialect
         open-in-view: false
+
 eureka:
     client:
         fetch-registry: true
@@ -26,5 +27,7 @@ eureka:
     instance:
         instance-id: user-service-${spring.application.instance-id:${random.value}}
         prefer-ip-address: true
-server:
-    port: 8081
+logging:
+    level:
+        org.springframework.cloud: DEBUG
+        org.springframework.web.client.RestTemplate: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈

#28 

## ✨ PR 세부 내용

- docker 환경에서 config-server의 정보를 가져오는 config-client들이 config-server가 git의 정보를 다 가져오기 전에 통신을 시도하려는 경우가 발생
- 이를 수정하는 작업을 수행
- 먼저 config-client에서 config-server의 값을 가져오지 못하면 종료되게 설정
- docker-compose.yml에서 config-client가 종료되면 계속해서 config-server에 요청 다시 보내도록 설정

