### PR TITLE
Error#48 email validate

### DIFF
--- a/keupang-user/src/main/java/com/example/keupanguser/service/UserService.java
+++ b/keupang-user/src/main/java/com/example/keupanguser/service/UserService.java
@@ -8,8 +8,6 @@ import com.example.keupanguser.request.LoginRequest;
 import com.example.keupanguser.request.UserRequest;
 import com.example.keupanguser.response.LoginResponse;
 import java.time.Duration;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -26,7 +24,6 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RedisTemplate<String, Object> redisTemplate;
-    private final Map<String, String> verificationCodes = new HashMap<>();
     private static final long JWT_EXPIRE_TIME = 2; // JWT 만료 시간
     private static final long EMAIL_CODE_EXPIRE_TIME = 5; // EMAIL_CODE 만료 시간
 
@@ -76,7 +73,8 @@ public class UserService {
 
         // Redis에 토큰 저장
         String redisKey = "user:token:" + user.getUserEmail();
-        redisTemplate.opsForValue().set(redisKey, token, Duration.ofHours(JWT_EXPIRE_TIME)); //JWT 만료
+        redisTemplate.opsForValue()
+            .set(redisKey, token, Duration.ofHours(JWT_EXPIRE_TIME)); //JWT 만료
 
         log.info("redis 저장 : {} = {}", redisKey, token);
 
@@ -94,17 +92,18 @@ public class UserService {
     public String generateVerificationCode(String email) {
         String code = String.format("%06d", (int) (Math.random() * 1_000_000));
         String redisKey = "email:verification:" + email;
-        redisTemplate.opsForValue().set(redisKey, code, Duration.ofMinutes(EMAIL_CODE_EXPIRE_TIME)); //이메일 인증 코드 만료
-        verificationCodes.put(email, code);
-        log.info("Generated verification code for {}: {}", email, code);
+        redisTemplate.opsForValue()
+            .set(redisKey, code, Duration.ofMinutes(EMAIL_CODE_EXPIRE_TIME)); //이메일 인증 코드 만료
+        log.info("Generated verification code to Redis {}: {}", redisKey, code);
         return code;
     }
 
     public boolean verifyCode(String email, String code) {
-        String savedCode = verificationCodes.get(email);
+        String redisKey = "email:verification:" + email;
+        String savedCode = (String) redisTemplate.opsForValue().get(redisKey);
         if (savedCode != null && savedCode.equals(code)) {
-            verificationCodes.remove(email);
-            log.info("Email {} verified successfully.", email);
+            redisTemplate.delete(redisKey); //인증 후 코드 삭제
+            log.info("Verification code for {} verified successfully.", email);
             return true;
         }
         log.warn("Verification failed for email {}: provided code {}", email, code);


### PR DESCRIPTION
## 📌 관련 이슈

closed: #48 

## ✨ PR 세부 내용

- 이메인 인증 코드를 service 클래스에서 Map 자료구조에 저장을 한 상황이었음.
- 이때, eureka 에서 자동으로 서버를 분리하고, api gateway에서 로드밸런싱을 하면서 다른 서버에서 인증 코드에 접근할 경우 인증 오류가 발생.
- 결과적으로 별개의 서버인 redis로 인증 정보를 저장하면서 문제를 해결함. (redis에 저장하면서 만료시간도 지정할 수 있어서 좋은 효과)
