### PR TITLE
chore: 외부 API URL 설정 환경변수화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,8 @@ AWS_S3_REGION=ap-northeast-2
 
 # Public API URL used by OpenAPI/Swagger metadata
 GATEWAY_PUBLIC_URL=https://api.example.com
+
+# Gateway CORS allowed origins
+FRONTEND_LOCAL_ORIGIN=http://localhost:5173
+FRONTEND_PUBLIC_ORIGIN=https://www.example.com
+FRONTEND_ROOT_ORIGIN=https://example.com

--- a/keupang-auth/src/main/resources/application.yml
+++ b/keupang-auth/src/main/resources/application.yml
@@ -19,7 +19,7 @@ springdoc:
 openapi:
     service:
         # API Gateway 포트
-        url: https://api.keupang.store
+        url: "${GATEWAY_PUBLIC_URL:http://localhost:8080}"
 
 eureka:
     client:

--- a/keupang-gateway/src/main/resources/application.yml
+++ b/keupang-gateway/src/main/resources/application.yml
@@ -8,10 +8,10 @@ spring:
                 cors-configurations:
                     '[/**]':
                         allowedOrigins:
-                            - "http://localhost:5173"
-                            - "https://www.keupang.store"
-                            - "https://api.keupang.store"
-                            - "https://keupang.store"
+                            - "${FRONTEND_LOCAL_ORIGIN:http://localhost:5173}"
+                            - "${FRONTEND_PUBLIC_ORIGIN:https://www.example.com}"
+                            - "${FRONTEND_ROOT_ORIGIN:https://example.com}"
+                            - "${GATEWAY_PUBLIC_URL:http://localhost:8080}"
                         allowedMethods:
                             - GET
                             - POST

--- a/keupang-product/src/main/resources/application.yml
+++ b/keupang-product/src/main/resources/application.yml
@@ -31,7 +31,7 @@ springdoc:
 openapi:
     service:
         # API Gateway 포트
-        url: https://api.keupang.store
+        url: "${GATEWAY_PUBLIC_URL:http://localhost:8080}"
 
 eureka:
     client:

--- a/keupang-review/src/main/resources/application.yml
+++ b/keupang-review/src/main/resources/application.yml
@@ -26,7 +26,7 @@ springdoc:
 openapi:
     service:
         # API Gateway 포트
-        url: https://api.keupang.store
+        url: "${GATEWAY_PUBLIC_URL:http://localhost:8080}"
 
 eureka:
     client:

--- a/keupang-stock/src/main/resources/application.yml
+++ b/keupang-stock/src/main/resources/application.yml
@@ -31,7 +31,7 @@ springdoc:
 openapi:
     service:
         # API Gateway 포트
-        url: https://api.keupang.store
+        url: "${GATEWAY_PUBLIC_URL:http://localhost:8080}"
 
 eureka:
     client:

--- a/keupang-user/src/main/resources/application.yml
+++ b/keupang-user/src/main/resources/application.yml
@@ -53,4 +53,4 @@ springdoc:
 openapi:
     service:
         # API Gateway 포트
-        url: https://api.keupang.store
+        url: "${GATEWAY_PUBLIC_URL:http://localhost:8080}"


### PR DESCRIPTION
## 📌 관련 이슈
close #98 

## ✨ PR 세부 내용
- 각 서비스의 `openapi.service.url`을 `GATEWAY_PUBLIC_URL` 기반으로 변경
- Gateway CORS 허용 origin을 환경변수 기반으로 변경
- `.env.example`에 프론트 도메인 관련 CORS 환경변수 추가  

