### PR TITLE
chore(ci): update Jenkins deploy pipeline for mini PC (#106)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,66 +1,41 @@
 pipeline {
     agent any
 
+    options {
+        disableConcurrentBuilds()
+        timestamps()
+    }
+
     environment {
         GIT_REPO = 'https://github.com/keupang/keupang-backend.git'
-        GIT_CREDENTIALS = 'github-key' // Credential ID
-        DOCKER_HUB_CREDENTIALS = 'docker-key' // Docker Hub Credentials ID
-        SLACK_CHANNEL = '#keupang-back' // Slack 채널 이름
-        SLACK_CREDENTIAL_ID = 'slack-key' // Jenkins에 저장한 Slack Webhook Credential ID
+        GIT_CREDENTIALS = 'github-key'
+        DEPLOY_BRANCH = 'prod'
+        COMPOSE_FILE = 'compose.deploy.yml'
+        ENV_FILE_CREDENTIALS = 'keupang-backend-env'
     }
 
     stages {
         stage('Checkout') {
             steps {
-                echo 'Checking out source code...'
-                git branch: 'prod', credentialsId: "${GIT_CREDENTIALS}", url: "${GIT_REPO}"
+                git branch: "${DEPLOY_BRANCH}", credentialsId: "${GIT_CREDENTIALS}", url: "${GIT_REPO}"
             }
         }
 
-        stage('Build Projects') {
+        stage('Build') {
             steps {
-                echo 'Building all projects...'
-                sh '''
-                # 각 프로젝트를 Gradle로 빌드
-                ./gradlew clean build
-                '''
+                sh './gradlew clean build'
             }
         }
 
-        stage('Docker Build and Push') {
+        stage('Deploy') {
             steps {
-                echo 'Building Docker images and pushing to Docker Hub...'
-                withCredentials([usernamePassword(credentialsId: "${DOCKER_HUB_CREDENTIALS}", usernameVariable: "DOCKER_USER", passwordVariable: "DOCKER_PASS")]) {
+                withCredentials([file(credentialsId: "${ENV_FILE_CREDENTIALS}", variable: 'DEPLOY_ENV_FILE')]) {
                     sh '''
-                    # Docker Hub 로그인
-                    echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
-
-                    # 각 프로젝트의 Dockerfile을 사용하여 이미지 빌드 및 Push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-config-server:1.0 ./keupang-config-server --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-eureka-server:1.0 ./keupang-eureka-server --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-api-gateway:1.0 ./keupang-gateway --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-service-product:1.0 ./keupang-product --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-service-user:1.0 ./keupang-user --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-service-auth:1.0 ./keupang-auth --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-service-stock:1.0 ./keupang-stock --push
-                    docker buildx build --platform linux/amd64,linux/arm64 -t playdodo/keupang-service-review:1.0 ./keupang-review --push
-                    '''
-                }
-            }
-        }
-
-        stage('Deploy to Server') {
-            steps {
-                echo 'Deploying on the server...'
-                sshagent(['server-ssh-key']) { // 서버 접속을 위한 SSH 키의 Credential ID
-                    sh '''
-                    # 서버에 SSH로 접속해서 이미지 Pull 및 Compose 실행
-                    ssh -o StrictHostKeyChecking=no root@api.keupang.store << EOF
-                    cd /home
-                    docker compose pull
-                    docker compose up -d
-                    exit
-                    EOF
+                    set -e
+                    cp "$DEPLOY_ENV_FILE" .env.deploy
+                    docker compose --env-file .env.deploy -f "$COMPOSE_FILE" build
+                    docker compose --env-file .env.deploy -f "$COMPOSE_FILE" up -d --remove-orphans
+                    rm -f .env.deploy
                     '''
                 }
             }
@@ -68,16 +43,14 @@ pipeline {
     }
 
     post {
+        always {
+            sh 'rm -f .env.deploy'
+        }
         success {
-            echo '✅ CI/CD Pipeline completed successfully!'
-            slackSend(channel: "${SLACK_CHANNEL}", color: "good", message: "✅ CI/CD Pipeline completed successfully! Build #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            echo "Keupang backend deployed from ${DEPLOY_BRANCH}."
         }
         failure {
-            echo '❌ CI/CD Pipeline failed!'
-            slackSend(channel: "${SLACK_CHANNEL}", color: "danger", message: "❌ CI/CD Pipeline failed! Build #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
-        }
-        always {
-            echo '📋 CI/CD Pipeline finished.'
+            echo 'Keupang backend deployment failed.'
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #106 

## ✨ PR 세부 내용

  변경 내용:

  - Jenkinsfile:1 재구성
  - Docker Hub buildx push 제거
  - 원격 서버 SSH 배포 제거
  - prod 브랜치 checkout 유지
  - Jenkins가 미니 PC에서 직접 실행:
      - ./gradlew clean build
      - docker compose --env-file .env.deploy -f compose.deploy.yml build
      - docker compose --env-file .env.deploy -f compose.deploy.yml up -d --remove-orphans
  - Jenkins credential 정리:
      - Git checkout: github-key
      - 배포 env 파일: keupang-backend-env
  - 중복 배포 방지를 위해 disableConcurrentBuilds() 추가
  - 빌드 로그 시간 확인용 timestamps() 추가

  검증:

  - Jenkinsfile에서 기존 Docker Hub, SSH, api.keupang.store, Slack credential 참조 제거 확인
  - git diff --check 통과

  전제:

  - Jenkins agent가 미니 PC 안에서 실행되고 Docker CLI/Compose를 사용할 수 있어야 합니다.
  - Jenkins credential에 secret file 타입으로 .env 내용을 담은 keupang-backend-env를 만들어야 합니다.