### PR TITLE
chore(proxy): add Caddy API reverse proxy (#108)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,8 @@ AWS_S3_REGION=ap-northeast-2
 
 # Public API URL used by OpenAPI/Swagger metadata
 GATEWAY_PUBLIC_URL=https://api.example.com
-GATEWAY_HOST_PORT=8080
+API_DOMAIN=api.example.com
+CADDY_EMAIL=admin@example.com
 
 # Gateway CORS allowed origins
 FRONTEND_LOCAL_ORIGIN=http://localhost:5173

--- a/compose.deploy.yml
+++ b/compose.deploy.yml
@@ -39,6 +39,26 @@ services:
           - service-redis
     restart: unless-stopped
 
+  caddy:
+    image: caddy:2.8-alpine
+    container_name: keupang-caddy
+    environment:
+      API_DOMAIN: ${API_DOMAIN}
+      CADDY_EMAIL: ${CADDY_EMAIL}
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      gateway:
+        condition: service_started
+    networks:
+      - keupang-network
+    restart: unless-stopped
+
   eureka-server:
     build:
       context: ./keupang-eureka-server
@@ -83,8 +103,8 @@ services:
       FRONTEND_PUBLIC_ORIGIN: ${FRONTEND_PUBLIC_ORIGIN}
       FRONTEND_ROOT_ORIGIN: ${FRONTEND_ROOT_ORIGIN}
       TZ: Asia/Seoul
-    ports:
-      - "${GATEWAY_HOST_PORT:-8080}:8080"
+    expose:
+      - "8080"
     depends_on:
       eureka-server:
         condition: service_started
@@ -250,5 +270,7 @@ networks:
     driver: bridge
 
 volumes:
+  caddy-data:
+  caddy-config:
   mysql-data:
   redis-data:

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -1,0 +1,9 @@
+{
+    email {$CADDY_EMAIL}
+}
+
+{$API_DOMAIN} {
+    encode zstd gzip
+
+    reverse_proxy gateway:8080
+}

--- a/docs/reverse-proxy-deploy.md
+++ b/docs/reverse-proxy-deploy.md
@@ -1,0 +1,32 @@
+# Reverse Proxy Deployment
+
+## Mini PC network checklist
+
+- Point the API DNS record to the public IP that reaches the mini PC network.
+- Forward router ports `80` and `443` to the mini PC.
+- Allow inbound `80` and `443` on the mini PC firewall.
+- Keep Jenkins private. Do not route public traffic to Jenkins.
+
+## Runtime flow
+
+```text
+Vercel frontend
+  -> https://api.example.com
+  -> Caddy :443
+  -> keupang-gateway:8080
+  -> internal services
+```
+
+Only Caddy publishes host ports. Gateway and internal services stay on the Docker network.
+
+## Required env values
+
+Set these values in the Jenkins secret env file before deployment:
+
+```text
+API_DOMAIN=api.example.com
+CADDY_EMAIL=admin@example.com
+GATEWAY_PUBLIC_URL=https://api.example.com
+FRONTEND_PUBLIC_ORIGIN=https://www.example.com
+FRONTEND_ROOT_ORIGIN=https://example.com
+```


### PR DESCRIPTION
## 📌 관련 이슈

close #108 

## ✨ PR 세부 내용

변경 내용

- compose.deploy.yml:42에 Caddy 서비스 추가
- 외부 포트 80, 443은 Caddy만 노출
- Gateway는 ports 제거하고 expose: 8080만 유지
- Caddy가 Docker network 내부의 gateway:8080으로 프록시
- 인증서 저장용 caddy-data, caddy-config volume 추가
- docker/caddy/Caddyfile:1 추가
- {$API_DOMAIN} 기준 자동 HTTPS
- reverse_proxy gateway:8080
- .env.example:40 갱신
- API_DOMAIN
- CADDY_EMAIL
- 기존 GATEWAY_HOST_PORT 제거
- docs/reverse-proxy-deploy.md:1 추가
- DNS, 공유기 80/443 포트포워딩, 방화벽, Jenkins 비공개 운영 체크리스트 정리
