### PR TITLE
Fix Docker Java base image

### DIFF
--- a/keupang-auth/Dockerfile
+++ b/keupang-auth/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-config-server/Dockerfile
+++ b/keupang-config-server/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-eureka-server/Dockerfile
+++ b/keupang-eureka-server/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-gateway/Dockerfile
+++ b/keupang-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-product/Dockerfile
+++ b/keupang-product/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-review/Dockerfile
+++ b/keupang-review/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-stock/Dockerfile
+++ b/keupang-stock/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app

--- a/keupang-user/Dockerfile
+++ b/keupang-user/Dockerfile
@@ -1,5 +1,5 @@
 # 1. Base image
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk-jammy
 
 # 2. Work directory
 WORKDIR /app


### PR DESCRIPTION
## 📌 관련 이슈

> close #115 

## ✨ PR 세부 내용

- Replace unavailable `openjdk:17-jdk-slim` Docker base image with `eclipse-temurin:17-jdk-jammy`
